### PR TITLE
Adding a loopback transport perfect for mocking JSON-RPC clients/servers.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,9 @@ module.exports = {
             http: require('./transports/server/http'),
             tcp: require('./transports/server/tcp'),
             middleware: require('./transports/server/middleware')
+        },
+        shared: {
+            loopback: require('./transports/shared/loopback')
         }
     }
 };

--- a/lib/transports/shared/loopback.js
+++ b/lib/transports/shared/loopback.js
@@ -1,0 +1,30 @@
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+
+// The loopback transport allows you to mock a JSON-RPC interface where the client
+// and server are on the same process.
+function LoopbackTransport() {
+    // Set up the event emitter and create the property the server's message handler will bind to
+    EventEmitter.call(this);
+    this.handler = function fakeHandler() {};
+    return this;
+}
+
+// Inherit the event emitter methods
+util.inherits(LoopbackTransport, EventEmitter);
+
+// Create a fake shutdown method for the sake of API compatibility
+LoopbackTransport.prototype.shutdown = function shutdown(done) {
+    this.emit('shutdown');
+    if(done instanceof Function) done();
+};
+
+// Pass the client requests to the server handler, and the response handling is taken care of
+// by the client's response handler.
+LoopbackTransport.prototype.request = function request(body, callback) {
+    this.emit('message', body);
+    this.handler(body, callback);
+};
+
+// Export the Loopback object
+module.exports = LoopbackTransport;

--- a/test/full-stack.js
+++ b/test/full-stack.js
@@ -39,9 +39,8 @@ exports.failureTcp = function(test) {
     });
 };
 
-String.prototype.repeat = function( num )
-{
-        return new Array( num + 1 ).join( this );
+String.prototype.repeat = function(num) {
+        return new Array(num + 1).join(this);
 }
 
 function perf(testString, test) {

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ var ClientTcp = jsonrpc.transports.client.tcp;
 var ServerHttp = jsonrpc.transports.server.http;
 var ServerTcp = jsonrpc.transports.server.tcp;
 var ServerMiddleware = jsonrpc.transports.server.middleware;
+var Loopback = jsonrpc.transports.shared.loopback;
 var express = require('express');
 var http = require('http');
 
@@ -36,6 +37,25 @@ exports.failureTcp = function(test) {
             c.shutdown(function() {
                 server.shutdown(test.done.bind(test));
             });
+        });
+    });
+};
+
+exports.loopbackLoopback = function(test) {
+    test.expect(3);
+    var loopback = new Loopback();
+    var server = new Server(loopback, {
+        loopback: function(arg, callback) { callback(null, arg); },
+        failure: function(arg, callback) { callback(new Error("I have no idea what I'm doing.")); }
+    });
+    var client = new Client(loopback);
+    client.register(['loopback', 'failure']);
+    client.loopback('foo', function(err, result) {
+        test.equal('foo', result, 'loopback works as expected');
+        client.failure('foo', function(err, result) {
+            test.ok(!!err, 'error exists');
+            test.equal(err.message, "I have no idea what I'm doing.", 'error message transmitted successfully.');
+            test.done();
         });
     });
 };


### PR DESCRIPTION
cc @countrodrigo 
