### PR TITLE
Fix client crash if corrupt TCP packet makes it through

### DIFF
--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -6,7 +6,7 @@ var shared = require('../shared/tcp');
 // Client Transport's data handling function, bound to the TcpTransport
 // instance when attached to the data event handler
 function onDataCallback(message) {
-    if(this.requests[message.id]) {
+    if(message && this.requests[message.id]) {
         this.requests[message.id].callback(message);
         delete this.requests[message.id];
     }


### PR DESCRIPTION
If a corrupt TCP packet makes it through and causes a JSON.parse error, the code was supposed to emit a 'babel' event and reconnect, but a bug in the client data callback code caused it to crash, instead.
