### PR TITLE
Adding a REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ The TCP transport is nearly 25x faster for small messages than for large.
 
     npm install multitransport-jsonrpc
 
-## Usage
+If you want to use the ``jsonrpc-repl`` binary, also
+
+    npm install -g multitransport-jsonrpc
+
+## Library Usage
 
 ```js
 var jsonrpc = require('multitransport-jsonrpc'); // Get the multitransport JSON-RPC suite
@@ -259,6 +263,20 @@ On the client side, you can only use the methods in an asynchronous way. All ass
 ```js
 jsonRpcClient.request("shutdown", ["arg1", "arg2"], callbackFunc);
 ```
+
+# Using the jsonrpc-repl binary
+
+    Usage: jsonrpc-repl [options]
+    
+    Options:
+    
+        -h, --help               output usage information
+        -s, --server <hostname>  The hostname the server is located on. (Default: "localhost")
+        -p, --port <portnumber>  The port the server is bound to. (Default: 80)
+        -t, --tcp                Connects to the server via TCP instead of HTTP (Default: false)
+
+The ``jsonrpc-repl`` dumps you into a [Node.js repl](http://nodejs.org/api/repl.html) with some bootstrapping done on connecting you to the RPC server and getting a list of valid server methods. You can access them with the ``rpc`` object in the exact same way as described above in the "Using JSON-RPC Client Methods" section. 
+
 
 ## Creating A New Transport
 

--- a/bin/jsonrpc-repl
+++ b/bin/jsonrpc-repl
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+var repl = require('repl');
+var commander = require('commander');
+var l = require('lambda-js');
+var jsonrpc = require('../lib/index');
+var Client = jsonrpc.client;
+var TcpTransport = jsonrpc.transports.client.tcp;
+var HttpTransport = jsonrpc.transports.client.http;
+
+commander
+    .option('-s, --server <hostname>', 'The hostname the server is located on. (Default: "localhost")', 'localhost')
+    .option('-p, --port <portnumber>', 'The port the server is bound to. (Default: 80)', 80)
+    .option('-t, --tcp', 'Connects to the server via TCP instead of HTTP (Default: false)', false)
+    .parse(process.argv);
+
+var Transport = commander.tcp ? TcpTransport : HttpTransport;
+
+new Client(new Transport(commander.server, commander.port), {}, function(client) {
+    console.log('Connected to ' + commander.server + ':' + commander.port + ' over ' + (commander.tcp ? 'TCP' : 'HTTP'));
+    console.log('The server reported the following methods:');
+    console.log(Object.getOwnPropertyNames(client).filter(l('name', 'name !== "transport"')).join(', '));
+    console.log('Access them with `rpc.foo(arg1, arg2, callbackFunction)`');
+    var r = repl.start('jsonrpc> ');
+    r.context.rpc = client;
+    r.on('exit', process.exit.bind(process));
+});

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
         "url": "git://git@github.com:uber/multitransport-jsonrpc.git"
     },
 	"main": "lib/index.js",
+    "bin": {
+        "jsonrpc-repl": "bin/jsonrpc-repl"
+    },
     "dependencies": {
         "queue-flow": "*",
-        "lambda-js": "*"
+        "lambda-js": "*",
+        "commander": "*"
     },
     "devDependencies": {
         "nodeunit": "*",


### PR DESCRIPTION
Adding a REPL to multitransport-jsonrpc so you can easily connect to a server and test the remote methods from the command line.

Don't merge yet, if this seems like a good idea, I'll need to write up a new section for the readme explaining how to use it (don't want to do that until the CLI app's command-line parameters are finalized).

cc @countrodrigo @squamos 
