### PR TITLE
Fix Out-of-Sockets Crash

### DIFF
--- a/lib/transports/shared/tcp.js
+++ b/lib/transports/shared/tcp.js
@@ -94,6 +94,7 @@ function parseBuffer(buffers, messageLen, eventEmitter) {
 function createDataHandler(self, callback) {
     var buffers = [], bufferLen = 0, messageLen = 0;
     return function dataHandler(data) {
+        if(!data) { return; } // Should we emit some sort of error here?
         if(buffers[buffers.length-1] && buffers[buffers.length-1].length < 4) {
             buffers[buffers.length-1] = Buffer.concat([buffers[buffers.length-1], data], buffers[buffers.length-1].length + data.length);
         } else {


### PR DESCRIPTION
The TCP data handler can crash if it is called without being provided a Buffer object, which can apparently happen if Node.js suddenly runs out of sockets.

cc @squamos 
