### PR TITLE
Don't mask server failures

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -52,7 +52,9 @@ JSONRPC.prototype.request = function(method, args, callback) {
         if(callback instanceof Function) {
             if(response.error) {
                 if(response.error.message) {
-                    callback(new Error(response.error.message));
+                    var err = new Error(response.error.message);
+                    err.stack = response.error.stack;
+                    callback(err);
                 } else {
                     callback(new Error(response.error));
                 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,47 +65,23 @@ JSONRPC.prototype.handleJSON = function handleJSON(data, callback) {
                 } else {
                     data.params = [next];
                 }
-                // This *try-catch* block seems pointless, since it is
-                // not possible to *catch* an error further into a
-                // *CPS* stack, but if the (normally short) blocking
-                // portion of the call throws an error, this will
-                // prevent the *Node.js* server from crashing.
+                // This *try-catch* block is for catching errors in an asynchronous server method.
+                // Since the async methods are supposed to return an error in the callback, this
+                // is assumed to be an unintended mistake, so we catch the error, send a JSON-RPC
+                // error response, and then re-throw the error so the server code gets the error
+                // and can deal with it appropriately (which could be "crash because this isn't
+                // expected to happen").
                 try {
                     this.scope[data.method].apply(this.scope, data.params);
                 } catch(e) {
                     var outErr = {};
                     outErr.message = e.message ? e.message : "";
+                    outErr.stack = e.stack ? e.stack : "";
                     var outObj = { result: null, error: outErr };
                     if(data.id) outObj.id = data.id;
                     callback(outObj);
+                    throw e;
                 }
-                // A blocking function will *return* a value immediately or
-                // *throw* an error, so this portion consists only of a
-                // *try-catch* block, but is otherwise identical to the
-                // above nonblocking code.
-            } else if(this.scope[data.method] && this.scope[data.method].blocking) {
-                if(data.params && !(data.params instanceof Array)) {
-                    data.params = [data.params];
-                } else if(!data.params) {
-                    data.params = [];
-                }
-                try {
-                    var outObj = { result: this.scope[data.method].apply(this.scope, data.params), error: null };
-                    outObj.id = data.id || undefined;
-                    callback(outObj);
-                } catch(e) {
-                    var outErr;
-                    if(e instanceof Error) {
-                        outErr = { message: e.message ? e.message : "" };
-                    } else {
-                        outErr = { message: e };
-                    }
-                    var outObj = { result: null, error: outErr };
-                    if(data.id) outObj.id = data.id;
-                    callback(outObj);
-                }
-                // If the interpretation of the POSTed data fails at any
-                // point, be sure to return a meaningful error message.
             } else {
                 callback({result:null, error:{message:"Requested method does not exist."}, id:-1});
             }
@@ -130,10 +106,19 @@ JSONRPC.prototype.register = function(methodName, method) {
     this.scope[methodName] = method;
 };
 
-// Make a ``blocking`` helper method to identify blocking methods as blocking (if the heuristic fails)
+// Make a ``blocking`` helper method to async-ify them
 JSONRPC.prototype.blocking = function blocking(func) {
-    func.blocking = true;
-    return func;
+    return function blocked() {
+        var args = Array.prototype.slice.call(arguments, 0, arguments.length-1);
+        var callback = arguments[arguments.length-1];
+        var err, res;
+        try {
+            res = func.apply(this, args);
+        } catch(e) {
+            err = e; // Doesn't throw because it's the only way to return an error with sync methods
+        }
+        callback(err, res);
+    };
 };
 
 // Cleanly shut down the JSONRPC server


### PR DESCRIPTION
Altering the server so it re-throws thrown errors from async methods so the server is aware of them and can clean up if necessary. Also refactored the code a bit to remove a large-ish branch and provide the client with the server's stack trace (may make that configurable in the future, but its great for debugging).

cc @squamos 
