### PR TITLE
Fix Client Reconnect Logic

### DIFF
--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -15,9 +15,11 @@ function onDataCallback(message) {
 // The handler for a connection close. Will try to reconnect if configured
 // to do so and it hasn't tried "too much," otherwise mark the connection
 // dead.
-function onEnd() {
+function onClose() {
+    this.logger('onClose ' + (this.con && this.con.random));
     // Attempting to reconnect
     if(this.retries && this.retry < this.retries) {
+        this.logger('onClose if (retries) - old con is: ' + (this.con && this.con.random));
         this.emit('retry');
         // When reconnecting, all previous buffered data is invalid, so wipe
         // it out, and then increment the retry flag
@@ -25,11 +27,19 @@ function onEnd() {
         // At the interval specified by the user, attempt to reestablish the
         // connection
         var reconnect = function reconnect() {
+            this.logger('onClose.reconnect - old con is: ' + (this.con && this.con.random));
+            var oldPort = this.con && this.con.random;
             // Set the connection reference to the new connection
+            if (this.con) {
+                this.logger('ERRORRORO connection should not be set');
+                this.con.destroy();
+                this.con = null;
+            }
             this.con = net.connect({
                 host: this.server,
                 port: this.port
             }, function() {
+                this.logger('net.connect.callback - new con: ' + (this.con && this.con.random) + '. old con: ' + oldPort);
                 // Clear the reconnect interval if successfully reconnected
                 if(this.reconnectInterval) clearInterval(this.reconnectInterval);
                 if(this.stopBufferingAfter) {
@@ -51,17 +61,41 @@ function onEnd() {
                     }.bind(this));
                 }.bind(this));
             }.bind(this));
+            this.con.random = Math.random();
+            this.logger('new.con.created - con: ' + (this.con && this.con.random));
             // Reconnect the data and end event handlers to the new connection object
             this.con.on('data', shared.createDataHandler(this, onDataCallback.bind(this)));
-            this.con.on('end', onEnd.bind(this));
-            this.con.on('error', function() {
+            this.con.on('end', function() {
+                this.logger('con.end - ' + (this.con && this.con.random));
                 this.con.destroy();
+            }.bind(this));
+            this.con.on('error', function() {
+                this.logger('con.error - ' + (this.con && this.con.random));
+                this.con.destroy();
+            }.bind(this));
+            this.con.on('close', function () {
+                this.logger('con.close - ' + (this.con && this.con.random));
+                if(this.con) {
+                    this.con.destroy();
+                    this.con = null;
+                    onClose.call(this);
+                }
             }.bind(this));
         };
         // If this is the first try, attempt to reconnect immediately
-        if(this.retry === 1) reconnect.call(this);
-        if(this.stopBufferingAfter) this.stopBufferingTimeout = setTimeout(this.stopBuffering.bind(this), this.stopBufferingAfter);
-        this.reconnectInterval = setInterval(reconnect.bind(this), this.retryInterval);
+        if(this.retry === 1) {
+            this.logger('call onClose.reconnect for retry === 1 - old con: ' + (this.con && this.con.random));
+            reconnect.call(this);
+        }
+        if(this.stopBufferingAfter && !this.stopBufferingTimeout) {
+            this.stopBufferingTimeout = setTimeout(this.stopBuffering.bind(this), this.stopBufferingAfter);
+        }
+        if(!this.reconnectInterval) {
+            this.reconnectInterval = setInterval(function() {
+                this.logger('call onClose.reconnect from reconnectInterval - old con: ' + (this.con && this.con.random));
+                reconnect.call(this);
+            }.bind(this), this.retryInterval);
+        }
     } else {
         // Too many tries, or not allowed to retry, mark the connection as dead
         this.emit('end');
@@ -82,6 +116,7 @@ function TcpTransport(server, port, config) {
     this.stopBufferingAfter = config.stopBufferingAfter || 0;
     this.stopBufferingTimeout = null;
     this.reconnectInterval = null;
+    this.logger = config.logger || function() {};
 
     // Set up the server connection and request-handling properties
     this.server = server;
@@ -100,17 +135,32 @@ function TcpTransport(server, port, config) {
     });
 
     // And handle incoming data and connection closing
+    this.con.random = Math.random();
     this.con.on('data', shared.createDataHandler(this, onDataCallback.bind(this)));
-    this.con.on('end', onEnd.bind(this));
-    this.con.on('error', function() {
+    this.con.on('end', function() {
+        this.logger('con.end - conn: ' + (this.con && this.con.random));
         this.con.destroy();
-        onEnd.call(this);
+        //this.con = null;
+    }.bind(this));
+    this.con.on('error', function() {
+        this.logger('con.error - conn: ' + (this.con && this.con.random));
+        this.con.destroy();
+        //this.con = null;
     }.bind(this));
     this.on('error', function() {
+        this.logger('client.error - conn: ' + (this.con && this.con.random));
         // Shared TCP code failed to parse a message, which means corrupt data from the server
         // Emit the 'babel' event and how many requests are being retried
         this.emit('babel', this.requests.length);
         this.con.destroy();
+    }.bind(this));
+    this.con.on('close', function() {
+        this.logger('conn.close ' + (this.con && this.con.random));
+        if(this.con) {
+            this.con.destroy();
+            this.con = null;
+            onClose.call(this);
+        }
     }.bind(this));
 
     return this;
@@ -120,6 +170,7 @@ function TcpTransport(server, port, config) {
 util.inherits(TcpTransport, EventEmitter);
 
 TcpTransport.prototype.stopBuffering = function stopBuffering() {
+    this.logger('Stopping the buffering of requests on ' + (this.con && this.con.random));
     this._request = this.request;
     this.request = function fakeRequest(body, callback) {
         callback(new Error('Connection Unavailable'));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "Amos Barreto <amos.barreto@gmail.com>"
 	],
 	"name": "multitransport-jsonrpc",
-	"version": "0.3.13",
+	"version": "0.3.14",
 	"description": "JSON-RPC where performance matters",
     "keywords": ["json-rpc", "http", "tcp", "multitransport"],
     "homepage": "http://uber.github.com/multitransport-jsonrpc/",


### PR DESCRIPTION
Fixing the reconnect logic of the TCP client so it can't freak out and swallow all possible TCP connections. Also added in the ability to optionally log debug info.

cc @squamos 
