### PR TITLE
User tomfoolery shouldn't impact sublime TCP handling.

### DIFF
--- a/lib/transports/shared/tcp.js
+++ b/lib/transports/shared/tcp.js
@@ -108,7 +108,12 @@ function createDataHandler(self, callback) {
                 buffers = result[0];
                 obj = result[1];
                 self.emit('message', obj, messageLen);
-                callback(obj);
+                try {
+                    callback(obj);
+                } catch(e) {
+                    /* jshint loopfunc: true */
+                    process.nextTick(function() { throw e; });
+                }
                 bufferLen = bufferLen - (messageLen + 4);
                 messageLen = getMessageLen(buffers);
             }

--- a/test/jshint.json
+++ b/test/jshint.json
@@ -17,7 +17,6 @@
     "unused": true,
     "strict": false,
     "trailing": true,
-    "es5": true,
     "node": true,
     "noempty": true,
     "maxdepth": 4,


### PR DESCRIPTION
Wrap the callback in a try-catch block and throw in a separate event loop run to keep the TCP message array correct even if the user's code breaks.

cc @squamos 
