### PR TITLE
Fix Client TCP Transport Error Reporting

### DIFF
--- a/lib/transports/client/childProcess.js
+++ b/lib/transports/client/childProcess.js
@@ -57,7 +57,7 @@ ChildProcessTransport.prototype.sweep = function sweep() {
     var cannedRequests = {};
     for(var key in this.requests) {
         if(this.requests[key].timestamp && this.requests[key].timestamp + this.timeout < now) {
-            this.requests[key].callback(new Error('Request Timed Out'));
+            this.requests[key].callback({ error: 'Request Timed Out' });
             cannedRequests[key] = this.requests[key];
             delete this.requests[key];
         }

--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -156,7 +156,7 @@ TcpTransport.prototype.stopBuffering = function stopBuffering() {
     this.logger('Stopping the buffering of requests on ' + (this.con && this.con.random));
     this._request = this.request;
     this.request = function fakeRequest(body, callback) {
-        callback(new Error('Connection Unavailable'));
+        callback({ error: 'Connection Unavailable' });
     };
 };
 
@@ -170,7 +170,7 @@ TcpTransport.prototype.request = function request(body, callback) {
     this.requests[body.id] = {
         callback: callback,
         body: body,
-        timestamp: new Date().getTime()
+        timestamp: Date.now()
     };
     if(this.con) this.con.write(shared.formatMessage(body, this));
 };
@@ -183,7 +183,7 @@ TcpTransport.prototype.sweep = function sweep() {
     var cannedRequests = {};
     for(var key in this.requests) {
         if(this.requests[key].timestamp && this.requests[key].timestamp + this.timeout < now) {
-            this.requests[key].callback(new Error('Request Timed Out'));
+            this.requests[key].callback({ error: 'Request Timed Out' });
             cannedRequests[key] = this.requests[key];
             delete this.requests[key];
         }
@@ -196,6 +196,7 @@ TcpTransport.prototype.sweep = function sweep() {
 // connection is ended, and a callback, if any, is called.
 TcpTransport.prototype.shutdown = function shutdown(done) {
     clearInterval(this.sweepInterval);
+    if(this.reconnectInterval) clearInterval(this.reconnectInterval);
     this.requests = {};
     this.retries = 0;
     if(this.con) this.con.destroy();

--- a/test/client-tcp.js
+++ b/test/client-tcp.js
@@ -125,14 +125,14 @@ exports.stopBuffering = function(test) {
     });
     // Early messages will be attempted and eventually time out
     tcpTransport.request({id: 'foo'}, function(result) {
-        test.ok(result instanceof Error, "Couldn't connect to the (nonexistent) server");
-        test.equal(result.message, 'Request Timed Out', 'time out error message received');
+        test.ok(!!result.error, "Couldn't connect to the (nonexistent) server");
+        test.equal(result.error, 'Request Timed Out', 'time out error message received');
     });
     // Later messages will be immediately killed
     setTimeout(function() {
         tcpTransport.request({id: 'foo'}, function(result) {
-            test.ok(result instanceof Error, "Still can't connect to the nonexistent server");
-            test.equal(result.message, 'Connection Unavailable', 'immediately blocked by the maximum timeout time for the server');
+            test.ok(!!result.error, "Still can't connect to the nonexistent server");
+            test.equal(result.error, 'Connection Unavailable', 'immediately blocked by the maximum timeout time for the server');
             var serverFunc = function(c) {
                 con = c;
                 var buffer = new Buffer('');
@@ -179,8 +179,8 @@ exports.dontStopBuffering = function(test) {
         stopBufferingAfter: 8*1000
     });
     tcpTransport.request({id: 'foo'}, function(result) {
-        test.ok(result instanceof Error);
-        test.equal(result.message, 'Request Timed Out');
+        test.ok(!!result.error);
+        test.equal(result.error, 'Request Timed Out');
     });
     setTimeout(function() {
         tcpTransport.request({id: 'foo'}, function(result) {

--- a/test/full-stack.js
+++ b/test/full-stack.js
@@ -51,6 +51,18 @@ exports.failureTcp = function(test) {
     });
 };
 
+exports.sweepedRequest = function(test) {
+    test.expect(2);
+    var client = new Client(new ClientTcp('localhost', 44444));
+    client.register(['willNeverReachAServer']);
+    client.willNeverReachAServer(function(err) {
+        test.ok(err instanceof Error, 'received an error message');
+        test.equal(err.message, 'Request Timed Out', 'received the "sweep" error message');
+        client.shutdown();
+        test.done();
+    });
+};
+
 exports.loopbackLoopback = function(test) {
     test.expect(3);
     var loopback = new Loopback();


### PR DESCRIPTION
Forgot that the transport must only return JSON-RPC objects, the new Error stuff was breaking the client lib on actual connectivity errors.

cc @squamos 
