### PR TITLE
Fix client options null crash

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -17,7 +17,7 @@ function JSONRPC(transport, options, done) {
     this.transport = transport;
     // Parse any *options* provided to the client
     // If no *options* object provided, create an empty one
-    if(typeof(options) !== "object") {
+    if(typeof(options) !== "object" || options === null) {
         options = {};
     }
     // *autoRegister* methods from the server unless explicitly told otherwise


### PR DESCRIPTION
Javascript's type categorization continues to amaze and confuse. Adding in a check if null is passed in as the options object.

cc @squamos 
