### PR TITLE
Centralize Babel

### DIFF
--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -71,8 +71,6 @@ var connect = function connect(toReconnect) {
     }.bind(this));
     this.con.on('error', function() {
         this.logger('con.error - ' + (this.con && this.con.random));
-        // Emit the 'babel' event and how many requests are being retried
-        this.emit('babel', Object.keys(this.requests).length);
         this.con.destroy();
     }.bind(this));
     this.con.on('close', function () {

--- a/lib/transports/shared/tcp.js
+++ b/lib/transports/shared/tcp.js
@@ -85,6 +85,7 @@ function parseBuffer(buffers, messageLen, eventEmitter) {
     try {
         obj = JSON.parse(buf.toString());
     } catch (e) {
+        eventEmitter.emit('babel', buf.toString());
         eventEmitter.emit('error', e);
     }
     return [buffers, obj];


### PR DESCRIPTION
Moved the 'babel' event to the shared tcp code so both client and server emit it, and so it only fires when data is corrupted.

cc @countrodrigo 
