### PR TITLE
Keep all error properties

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -53,7 +53,9 @@ JSONRPC.prototype.request = function(method, args, callback) {
             if(response.error) {
                 if(response.error.message) {
                     var err = new Error(response.error.message);
-                    err.stack = response.error.stack;
+                    Object.keys(response.error).forEach(function(key) {
+                        if(key !== 'message') err[key] = response.error[key];
+                    });
                     callback(err);
                 } else {
                     callback(new Error(response.error));


### PR DESCRIPTION
Make sure all error properties are preserved when converting into an Error object.

cc @squamos 
