### PR TITLE
Add TCP client reconnect limiting logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ The various transports also provide events you can listen on, using the [Node.js
 
 ``retryInterval`` - The time, in ms, that the client will wait before reconnect attempts (default: 250ms)
 
+``reconnects`` - The number of times the client will reconnect after a connection is closed (default: Infinity)
+
+``reconnectClearInterval`` - The time, in ms, after which the reconnect counter is reset. Set to 0 to disable (default: 1 hour)
+
 ``stopBufferingAfter`` - The time, in ms, that the client will return errors immediately to the caller *while still attempting to reconnect to the server*. If 0, it will never immediately return errors (default: 0)
 
 The Client TCP Transport events are:
@@ -314,15 +318,15 @@ jsonRpcClient.request("shutdown", ["arg1", "arg2"], callbackFunc);
 # Using the jsonrpc-repl binary
 
     Usage: jsonrpc-repl [options]
-    
+
     Options:
-    
+
         -h, --help               output usage information
         -s, --server <hostname>  The hostname the server is located on. (Default: "localhost")
         -p, --port <portnumber>  The port the server is bound to. (Default: 80)
         -t, --tcp                Connects to the server via TCP instead of HTTP (Default: false)
 
-The ``jsonrpc-repl`` dumps you into a [Node.js repl](http://nodejs.org/api/repl.html) with some bootstrapping done on connecting you to the RPC server and getting a list of valid server methods. You can access them with the ``rpc`` object in the exact same way as described above in the "Using JSON-RPC Client Methods" section. 
+The ``jsonrpc-repl`` dumps you into a [Node.js repl](http://nodejs.org/api/repl.html) with some bootstrapping done on connecting you to the RPC server and getting a list of valid server methods. You can access them with the ``rpc`` object in the exact same way as described above in the "Using JSON-RPC Client Methods" section.
 
 
 ## Creating A New Transport

--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -45,6 +45,7 @@ var connect = function connect(toReconnect) {
             delete this._request;
         }
         this.retry = 0;
+        this.reconnect++;
         if(toReconnect) {
             // Get the list of all pending requests, place them in a private
             // variable, and reset the requests object
@@ -89,7 +90,7 @@ var connect = function connect(toReconnect) {
 onClose = function onClose() {
     this.logger('onClose ' + (this.con && this.con.random));
     // Attempting to reconnect
-    if(this.retries && this.retry < this.retries) {
+    if(this.retries && this.retry < this.retries && this.reconnect < this.reconnects) {
         this.logger('onClose if (retries) - old con is: ' + (this.con && this.con.random));
         this.emit('retry');
         // When reconnecting, all previous buffered data is invalid, so wipe
@@ -124,7 +125,10 @@ function TcpTransport(server, port, config) {
     // as the server and port
     config = config || {};
     this.retries = config.retries || Infinity;
+    this.reconnects = config.reconnects || Infinity;
+    this.reconnectClearInterval = config.reconnectClearInterval || 0;
     this.retry = 0;
+    this.reconnect = -1;
     this.retryInterval = config.retryInterval || 250;
     this.stopBufferingAfter = config.stopBufferingAfter || 0;
     this.stopBufferingTimeout = null;
@@ -141,6 +145,11 @@ function TcpTransport(server, port, config) {
     this.timeout = config.timeout || 30*1000;
     this.sweepIntervalMs = config.sweepIntervalMs || 1*1000;
     this.sweepInterval = setInterval(this.sweep.bind(this), this.sweepIntervalMs);
+
+    if (this.reconnectClearInterval > 0 && this.reconnectClearInterval !== Infinity) {
+        this.reconnectClearTimer = setInterval(this.clearReconnects.bind(this),
+                                               this.reconnectClearInterval);
+    }
 
     connect.call(this, false);
 
@@ -189,12 +198,23 @@ TcpTransport.prototype.sweep = function sweep() {
     this.emit('sweep', cannedRequests);
 };
 
+// The clearReconnects function periodically resets the internal counter
+// of how many times we have re-established a connection to the server.
+// If the connection is currently dead (undefined), it attempts a reconnect.
+TcpTransport.prototype.clearReconnects = function clearReconnects() {
+    this.reconnect = -1;
+    if (this.con === undefined) {
+        connect.call(this, true);
+    }
+};
+
 // When shutting down the client connection, the sweep is turned off, the
 // requests are removed, the number of allowed retries is set to zero, the
 // connection is ended, and a callback, if any, is called.
 TcpTransport.prototype.shutdown = function shutdown(done) {
     clearInterval(this.sweepInterval);
     if(this.reconnectInterval) clearInterval(this.reconnectInterval);
+    if(this.reconnectClearTimer) clearInterval(this.reconnectClearTimer);
     this.requests = {};
     this.retries = 0;
     if(this.con) this.con.destroy();


### PR DESCRIPTION
We ran into a bug in production today where haproxy had a port bound
with no backends, so it was immediately returning a null response. This
caused the client TcpTransport to get stuck in an infinite loop, since
it resets its `retry` count back to 0 after establishing a successful
connection.

Previously, if the connect was successfully opened, we considered that
as having a valid backend. However, for reasons mentioned above, it can
be useful to limit the number of times the transport will reconnect to a
server in a given time period. This commit adds two new parameters to
control this behavior.

cc @dfellis @squamos 
