### PR TITLE
Ban queue-flow 0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "jsonrpc-repl": "bin/jsonrpc-repl"
     },
     "dependencies": {
-        "queue-flow": "*",
+        "queue-flow": "<0.7.x",
         "lambda-js": "*",
         "commander": "*"
     },


### PR DESCRIPTION
queue-flow 0.7.x is unstable and not backwards compatible. Ban it from multitransport-jsonrpc

cc @jsu1212 
