### PR TITLE
Non-Error error responses not converted into Errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,8 +58,10 @@ JSONRPC.prototype.request = function(method, args, callback) {
                         if(key !== 'message') err[key] = response.error[key];
                     });
                     callback(err);
-                } else {
+                } else if (typeof response.error === 'string') {
                     callback(new Error(response.error));
+                } else {
+                    callback(response.error);
                 }
             } else {
                 callback(undefined, response.result);

--- a/test/full-stack.js
+++ b/test/full-stack.js
@@ -51,6 +51,25 @@ exports.failureTcp = function(test) {
     });
 };
 
+exports.objectFailureTcp = function(test) {
+    test.expect(4);
+    var server = new Server(new ServerTcp(44444), {
+        failure: function(arg, callback) { callback({ foo: "I have no idea what I'm doing." }); }
+    });
+    var client = new Client(new ClientTcp('localhost', 44444), {}, function(c) {
+        c.failure('foo', function(err) {
+            test.ok(!!err, 'error exists');
+            test.equal(err.foo, "I have no idea what I'm doing.", 'error message transmitted successfully.');
+            c.shutdown(function() {
+                server.shutdown(test.done.bind(test));
+            });
+        });
+    });
+    client.transport.on('message', function() {
+        test.ok('received a message'); // should happen twice
+    });
+};
+
 exports.sweepedRequest = function(test) {
     test.expect(2);
     var client = new Client(new ClientTcp('localhost', 44444));


### PR DESCRIPTION
If the error response doesn't look like an Error object, don't convert it into one.

cc @squamos 
