### PR TITLE
Exposes blocking() via server constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -110,7 +110,7 @@ JSONRPC.prototype.register = function(methodName, method) {
 };
 
 // Make a ``blocking`` helper method to async-ify them
-JSONRPC.prototype.blocking = function blocking(func) {
+JSONRPC.blocking = function blocking(func) {
     return function blocked() {
         var args = Array.prototype.slice.call(arguments, 0, arguments.length-1);
         var callback = arguments[arguments.length-1];


### PR DESCRIPTION
Per the README, blocking() should be exposed by the server constructor
function and not the instance objects. This makes sense for two reasons:
1. Developers should be able to define RPC methods prior to a server
   instance being created.
2. The implementation has no dependencies on the server instance.
