### PR TITLE
pass all keys in error objects

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -69,7 +69,11 @@ JSONRPC.prototype.handleJSON = function handleJSON(data, callback) {
                         outObj.result = null;
                         if(error instanceof Error) {
                             outObj.error = {};
-                            Object.keys(error).forEach(function (k) { outObj.error[k] = error[k]; });
+                            var keys = Object.keys(error);
+                            for (var i = 0; i < keys.length; ++i) {
+                                var key = keys[i];
+                                outObj.error[key] = error[key];
+                            }
                             outObj.error.code = errorCode.internalError;
                             outObj.error.message = error.message;
                         } else {

--- a/test/child/child.js
+++ b/test/child/child.js
@@ -7,6 +7,8 @@ var server = new JsonRpcServer(new JsonRpcChildProcTransport(), {
         callback(null, obj);
     },
     failure: function(obj, callback) {
-        callback(new Error("Whatchoo talkin' 'bout, Willis?"));
+        var error = new Error("Whatchoo talkin' 'bout, Willis?");
+        error.prop = 1;
+        callback(error);
     }
 });

--- a/test/client-childProccess.js
+++ b/test/client-childProccess.js
@@ -17,10 +17,11 @@ exports.loopback = function(test) {
 };
 
 exports.failureTcp = function(test) {
-    test.expect(2);
+    test.expect(3);
     jsonRpcClient.failure({foo: 'bar'}, function(err) {
         test.ok(!!err, 'error exists');
         test.equal("Whatchoo talkin' 'bout, Willis?", err.message, 'The error message was received correctly');
+        test.equal(1, err.prop, 'The error message was received correctly');
         child.kill();
         test.done();
     });


### PR DESCRIPTION
try #2, this just allows us to preserve any additional keys on error objects when returning them from a child in a callback.
