### PR TITLE
Fix Issue #59 Corner case in the retry buffering logic when buffering is set to zero

### DIFF
--- a/lib/transports/client/tcp.js
+++ b/lib/transports/client/tcp.js
@@ -98,7 +98,7 @@ onClose = function onClose() {
             this.logger('call onClose.reconnect for retry === 1 - old con: ' + (this.con && this.con.random));
             connect.call(this, true);
         }
-        if(typeof(this.stopBufferingAfter) === 'number' && !this.stopBufferingTimeout) {
+        if(typeof(this.stopBufferingAfter) === 'number' && this.stopBufferingAfter !== 0 && !this.stopBufferingTimeout) {
             this.stopBufferingTimeout = setTimeout(this.stopBuffering.bind(this), this.stopBufferingAfter);
         }
         if(!this.reconnectInterval) {


### PR DESCRIPTION
A refactor a year ago broke the semantics here.

This was not noticed because any non-trivial usage of the TCP Client should not allow messages to buffer indefinitely.
