### PR TITLE
Fix for argument ordering, and filling in "undefined" for missing params

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -89,13 +89,19 @@ JSONRPC.prototype.handleJSON = function handleJSON(data, callback) {
                     }
                     callback(outObj);
                 };
-                if(data.params && data.params instanceof Array) {
-                    data.params.push(next);
-                } else if(data.params) {
-                    data.params = [data.params, next];
-                } else {
-                    data.params = [next];
+
+                if (!(data.params instanceof Array)) {
+                  data.params = data.params ? [data.params] : [];
                 }
+
+                var paramsMissing = this.scope[data.method].length - (arglen + 1);
+
+                for (var j = 0; j < paramsMissing; j++) {
+                  data.params.push(undefined);
+                }
+
+                data.params.push(next);
+
                 // This *try-catch* block is for catching errors in an asynchronous server method.
                 // Since the async methods are supposed to return an error in the callback, this
                 // is assumed to be an unintended mistake, so we catch the error, send a JSON-RPC


### PR DESCRIPTION
This corresponds with #64 

I'd like to put this forward as the fix for that issue, but I have not run your test suite. Your tests don't really look like unit tests, so much as they are e2e tests that spin up some real servers on a few ports. This fix may very well pass them. (I'm kind of hoping putting in a PR kicks off a ci test).

If it does pass and you're satisfied with the fix, by all means merge it.

If not, close this PR. But please consider taking what I've done here and adding to it in order to resolve this issue in your own PR.