### PR TITLE
Added support for calling external methods without using a selector

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,6 +87,18 @@ JSONRPC.prototype.register = function(methods) {
                 var callback = arguments[arguments.length-1];
                 this.request(method, theArgs, callback);
             };
+            if(method.indexOf('.') > -1) {
+                var parts = method.split('.');
+                var target = this;
+                var selector = parts[parts.length-1];
+                for(var i = 0; i < parts.length-1; i++) {
+                    if(target[parts[i]] === undefined) {
+                        target[parts[i]] = {};
+                    }
+                    target = target[parts[i]];
+                }
+                target[selector] = this[method].bind(this);
+            }
         }
     }.bind(this));
 };


### PR DESCRIPTION
This commit adds support for direct addressing using the dot syntax of javascript instead of the square syntax.

This makes it possible to use jsonRpcTcpClient.rpc.methodList() instead of jsonRpcTcpClient["rpc.methodList"]()