### PR TITLE
Properly handle Errors when the server is down

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,10 @@ JSONRPC.prototype.request = function(method, args, callback) {
             return;
         }
         if(callback instanceof Function) {
-            if(response.error) {
+            if (response instanceof Error){
+                callback(response);
+            }
+            else if(response.error) {
                 if(response.error.message) {
                     var err = new Error(response.error.message);
                     Object.keys(response.error).forEach(function(key) {

--- a/test/client.js
+++ b/test/client.js
@@ -90,3 +90,13 @@ exports.invalidHttp = function(test) {
         server.close(test.done.bind(test));
     });
 };
+
+exports.serverDownHttp = function(test) {
+    test.expect(1);
+    var jsonRpcClient = new JSONRPCclient(new HttpTransport('localhost', 23232));
+    jsonRpcClient.register('foo');
+    jsonRpcClient.foo('bar', function(err) {
+        test.ok(err instanceof Error, 'received the error response from the client library');
+        test.done();
+    });
+};


### PR DESCRIPTION
This is a fix for: https://github.com/uber/multitransport-jsonrpc/issues/73
If the RPC server is down and an http client tries to make a request, the response from the http client is an Error object rather than an object with the field "error." This means that the error doesn't actually get properly returned to the callback.

This could also be fixed by making the http client wrap the error, but I put it into the lib/client.js file to be a bit more general of a fix.