### PR TITLE
Legacy versions of Node can't use newest NPM, don't install it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
     - 0.8
     - 0.10
     - 0.12
-before_install:
-  npm install -g npm
 
 after_script:
   npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
     - 0.8
     - 0.10
     - 0.12
+before_install:
+  npm install -g npm@1.4.x
 
 after_script:
   npm run coveralls


### PR DESCRIPTION
cc @depombo